### PR TITLE
BREAKING CHANGE: The exports from @testing-library/react  has been removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
   - 14
   - node
 before_install:
-  - npm install @testing-library/react react react-dom
+  - npm install @testing-library/dom
 install: npm install
 script:
   - npm run validate

--- a/package.json
+++ b/package.json
@@ -44,8 +44,6 @@
     "dist"
   ],
   "peerDependencies": {
-    "@testing-library/react": "^11.0.4",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "@testing-library/dom": "^7.24.5"
   }
 }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,8 +1,9 @@
-import * as rtlUtils from '@testing-library/react'
+// eslint-disable-next-line testing-library/no-dom-import
+import * as rtlUtils from '@testing-library/dom'
 import {screen} from '../'
 import {variants} from '../simple-queries'
 
-jest.mock('@testing-library/react')
+jest.mock('@testing-library/dom')
 describe('Cases of screen', () => {
   afterEach(() => {
     jest.resetAllMocks()

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import {getSimpleQueries, screen} from './simple-queries'
 
-export * from '@testing-library/react'
+export * from '@testing-library/dom'
 
 export {getSimpleQueries, screen}

--- a/src/simple-queries.js
+++ b/src/simple-queries.js
@@ -1,4 +1,5 @@
-import {screen as rtlScreen} from '@testing-library/react'
+// eslint-disable-next-line testing-library/no-dom-import
+import {screen as rtlScreen} from '@testing-library/dom'
 
 export const variants = [
   'LabelText',


### PR DESCRIPTION


This library uses @testing-library/dom and exports from it.

**What**:

It supports any library that uses `screen` from `@testing-library/dom`

**Why**:

To support sister testing libraries like `@testing-library/react`, `@testing-library/vue` etc

**How**:

Move the screen import from  `@testing-library/react` to `@testing-library/dom`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
